### PR TITLE
Invoke parse_filters in mqexec.c

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,10 @@ one address, list them as an array.::
 			"bind": "ipc:///var/nagios/nagmqstate.sock",
 			"threads": 2
 		},  
-		"executor": {
+   		"executor": {
+    			"filter": { 
+    				"match": "localhost",
+    				"field": "host_name"},
 			"jobs": "ipc:///var/nagios/mqexecjobs.sock",
 			"results": "ipc:///var/nagios/mqexecresults.sock"
 		},  
@@ -89,7 +92,16 @@ one address, list them as an array.::
 		]   
 	}
 
+
+Start the dnxmq broker and worker:
+
+    $ mqbroker /etc/nagios/nagmq.config
+    $ mqexec /etc/nagios/nagmq.config
+
 Restart Nagios, and you'll be able to connect to the message busses and
 get data into and out of the broker!
+
+If you do NOT wish to use dnxmq, remove the "override" directive from the
+sample "publisher" config.
 
 .. _`Apache Version 2 license`: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/dnxmq/mqexec.c
+++ b/dnxmq/mqexec.c
@@ -574,6 +574,8 @@ int main(int argc, char ** argv) {
 		exit(-1);
 	}
 
+	parse_filter(filter,0);
+
 	gethostname(myfqdn, sizeof(myfqdn));
 	gethostname(mynodename, sizeof(mynodename));
 	for(i = 0; i < sizeof(mynodename); i++) {


### PR DESCRIPTION
Currently the parse_filters() function in mqexec is not being invoked. The feature seems pretty complete - if this is just an omission can you merge? If the feature is not really considered ready to use then I understand.

I also updated the README to provide an example for filters and explain the mqexec/mqbroker a little bit more.
