### PR TITLE
ZMQ_IMMEDIATE was from 0MQ 3.3 onwards

### DIFF
--- a/dnxmq/mqexec.c
+++ b/dnxmq/mqexec.c
@@ -620,7 +620,7 @@ void parse_sock_directive(void * socket, json_t * arg, int bind) {
 			if(opt != ZMQ_SUB)
 				return;
 			opt = 1;
-#if ZMQ_VERSION_MAJOR < 3
+#if ZMQ_VERSION < 30300
 			zmq_setsockopt(socket, ZMQ_DELAY_ATTACH_ON_CONNECT, &opt, &optsize);
 #else
 			zmq_setsockopt(socket, ZMQ_IMMEDIATE, &opt, optsize);


### PR DESCRIPTION
See https://github.com/zeromq/zmqpp/pull/27
