### PR TITLE
Fixing up autoreconf issue with missing am_prog

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,7 @@ AC_ARG_WITH([pcre-config],
 	[pcre_config_prog=$withval])
 AC_PATH_PROG(PCRE_CONFIG, [pcre-config], $pcre_config_prog)
 
+AM_PROG_AR
 AC_PROG_CC
 AM_PROG_CC_C_O
 LT_PREREQ([2.2.6])


### PR DESCRIPTION
I'm working on a Gentoo/Funtoo/Meta Gentoo ebuild and I had to patch your configure.ac with AM_PROG_AR to get autotools working. I was able to get it build anyways if you don't want to accept this pull request.
